### PR TITLE
Support tf2 with compatible mode and pandas version 1.5.3 or later

### DIFF
--- a/model/model.py
+++ b/model/model.py
@@ -1,7 +1,12 @@
 import tensorflow as tf
+if tf.__version__.split(".")[0]=='2':
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
+    import tensorflow.compat.v1.keras as K
+else:
+    import tensorflow.contrib.keras as K
 from kgcn import layers
 from kgcn.default_model import DefaultModel
-import tensorflow.contrib.keras as K
 
 
 class GCN(DefaultModel):

--- a/model_modules.py
+++ b/model_modules.py
@@ -4,6 +4,9 @@ import sys
 from keras import models
 from rdkit import Chem
 import tensorflow as tf
+if tf.__version__.split(".")[0]=='2':
+    import tensorflow.compat.v1 as tf
+    tf.disable_v2_behavior()
 import numpy as np
 import torch
 

--- a/reimplemented_libraries/cxn_utils.py
+++ b/reimplemented_libraries/cxn_utils.py
@@ -29,7 +29,7 @@ class CxnUtils:
         self.rollout_list = self. __get_reaction_list(reaction_rule_list_path)
         self.max_products = max_products
     
-    def __get_reaction_list(self, reaction_rule_list_path: str, file_ext=".sma", file_sep="\n", header=None) -> List[str]:
+    def __get_reaction_list(self, reaction_rule_list_path: str, file_ext=".sma", file_sep="\t", header=None) -> List[str]:
         """ 
         Description:
             Read the file containing the list of available reaction rules in SMARTS string format.

--- a/reimplemented_libraries/utils/data_utils.py
+++ b/reimplemented_libraries/utils/data_utils.py
@@ -8,7 +8,7 @@ class DataUtils:
     """
 
     @staticmethod
-    def read_dataset(dataset_file_path: str, dataset_file_extension: str, separator="\n",
+    def read_dataset(dataset_file_path: str, dataset_file_extension: str, separator="\t",
                      header=0, verbose=False) -> pd.DataFrame:
         """
         Description:


### PR DESCRIPTION
1. Added code on import sections to support tf2 with compatibile mode in a similar way to kGCN
2. Since read_csv does not accept newline separators in pandas versions 1.5.3 and later, the default has been changed to tab.
https://github.com/pandas-dev/pandas/issues/51801